### PR TITLE
Allow HP values without formula

### DIFF
--- a/src/scripts/MarkdownParser.ts
+++ b/src/scripts/MarkdownParser.ts
@@ -120,7 +120,7 @@ class MarkdownParser {
      * @param text - markdown text
      */
     public getCreatureHP(text: string): object {
-        const match = text.match(/ \*\*Hit Points\*\* ([0-9]+) \((.*?)\)/);
+        const match = text.match(/ \*\*Hit Points\*\* ([0-9]+)(?: \((.*?)\))?/);
         return {
             HP: match[1],
             formula: match[2]


### PR DESCRIPTION
Not all monsters have a formula set for calculating their hp, especially those generated with GIFFYGLYPH'S monster maker.
This PR makes the formula part of the HP stat optional.