### PR TITLE
Greedy whitespace matching in Name parser.

### DIFF
--- a/scripts/MarkdownParser.js
+++ b/scripts/MarkdownParser.js
@@ -63,7 +63,7 @@ const _clearText = (text) => {
  * @param text - markdown text
  */
 const getCreatureName = (text) => {
-  const match = text.match(/> ## (.+)/);
+  const match = text.match(/>\s*##\s*(.+)/);
   if (!match) return;
   return match[1];
 };


### PR DESCRIPTION
Fix bug when importing CritterDB's markdown export, which has minor
differences from the Tetracube statblock importer.

Change spaces to greedy whitespace match in Name parser.

Edit: 
Removed reference to issue