### PR TITLE
Foundryv10 import fix

### DIFF
--- a/scripts/ActorCreator.js
+++ b/scripts/ActorCreator.js
@@ -220,12 +220,12 @@ const _makeAttributesStructure = (propsAttributes, creatureProficiency, abilitie
 const _makeResourcesStructure = (propsRes) => {
   return {
     legact: {
-      value: propsRes?.numberOfLegendaryActions,
-      max: propsRes?.numberOfLegendaryActions
+      value: propsRes?.numberOfLegendaryActions || 0,
+      max: propsRes?.numberOfLegendaryActions || 0
     },
     legres: {
-      value: propsRes?.numberOfLegendaryResistances,
-      max: propsRes?.numberOfLegendaryResistances
+      value: propsRes?.numberOfLegendaryResistances || 0,
+      max: propsRes?.numberOfLegendaryResistances || 0
     }
   };
 };

--- a/scripts/MarkdownParser.js
+++ b/scripts/MarkdownParser.js
@@ -434,9 +434,6 @@ const getLegendaryActions = (text) => {
  */
 const getNumberOfLegendaryActions = (text) => {
   const legendaryActionDescription = text.match(/> .* can take ([0-9]+) legendary actions, .*/);
-  if (legendaryActionDescription == null){
-	return Number(0);
-  }
   return Number(legendaryActionDescription?.[1]);
 };
 
@@ -447,9 +444,6 @@ const getNumberOfLegendaryActions = (text) => {
  */
 const getNumberOfLegendaryResistances = (text) => {
   const legendaryRes = text.match(/> \*\*\*Legendary Resistance \(([0-9]+)\/Day\)\.\*\*\*/);
-  if (legendaryRes == null){
-	return Number(0);
-  }
   return Number(legendaryRes?.[1]);
 };
 

--- a/scripts/MarkdownParser.js
+++ b/scripts/MarkdownParser.js
@@ -434,7 +434,9 @@ const getLegendaryActions = (text) => {
  */
 const getNumberOfLegendaryActions = (text) => {
   const legendaryActionDescription = text.match(/> .* can take ([0-9]+) legendary actions, .*/);
-
+  if (legendaryActionDescription == null){
+	return Number(0);
+  }
   return Number(legendaryActionDescription?.[1]);
 };
 
@@ -445,7 +447,9 @@ const getNumberOfLegendaryActions = (text) => {
  */
 const getNumberOfLegendaryResistances = (text) => {
   const legendaryRes = text.match(/> \*\*\*Legendary Resistance \(([0-9]+)\/Day\)\.\*\*\*/);
-
+  if (legendaryRes == null){
+	return Number(0);
+  }
   return Number(legendaryRes?.[1]);
 };
 


### PR DESCRIPTION
v10 fails to import statblocks that do NOT have legendary resistances/actions. This results in a null object that breaks import process. This fix defaults such cases to use int 0 when checking. Fix courtesy of @sneat.